### PR TITLE
add note to explain syntax error after completing a step

### DIFF
--- a/Workshop/step-2.md
+++ b/Workshop/step-2.md
@@ -66,7 +66,7 @@ Consider in our scenario we only support JPEG and PNG formats. The image analysi
 	 
 1. To ensure only JPEG and PNG images are allowed to be further processed, we create a Choice state that directs to the *NotSupportedImageType* Fail state when the image format is not JPEG or PNG. 
 
-	Add a **Choice** state after the **NotSupportedImageType** fail state: 
+	Add a **Choice** state after the **NotSupportedImageType** fail state (Note that after adding this block there will be a syntax error on one of the lines due to a missing state. This will get resolved after completing the next step): 
 
 	```JSON
 	  "ImageTypeCheck": {


### PR DESCRIPTION
*Description of changes:*

I just attended a workshop to go through this lab and there was a lot of confusion around step 2A.4. After adding the "ImageTypeCheck" state there is a syntax error (as shown below) due to the "Parallel" state not existing yet which gets added in the next step. Many people thought they were putting the block in the wrong location or that they had done something wrong. To alleviate this, a simple note can be added that this is expected.

![image](https://user-images.githubusercontent.com/20246072/54328207-0a089600-45db-11e9-9f39-e24bca9412e4.png)