### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/cloudformation/image-processing.output.yaml
+++ b/cloudformation/image-processing.output.yaml
@@ -133,7 +133,7 @@ Resources:
         Fn::GetAtt:
         - CustomResourceHelperRole
         - Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 200
     Type: AWS::Serverless::Function
   CustomResourceHelperRole:
@@ -186,7 +186,7 @@ Resources:
         Fn::GetAtt:
         - DescribeExecutionFunctionRole
         - Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 200
     Type: AWS::Serverless::Function
   DescribeExecutionFunctionRole:
@@ -233,7 +233,7 @@ Resources:
         Fn::GetAtt:
         - BackendProcessingLambdaRole
         - Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 200
     Type: AWS::Serverless::Function
   GenerateThumbnailFunction:
@@ -246,7 +246,7 @@ Resources:
         Fn::GetAtt:
         - BackendProcessingLambdaRole
         - Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 300
     Type: AWS::Serverless::Function
   ImageMetadataDDBTable:
@@ -295,7 +295,7 @@ Resources:
         Fn::GetAtt:
         - BackendProcessingLambdaRole
         - Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 60
     Type: AWS::Serverless::Function
   ImageProcStateMachine:
@@ -405,7 +405,7 @@ Resources:
         Fn::GetAtt:
         - BackendProcessingLambdaRole
         - Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 60
     Type: AWS::Serverless::Function
   S3EventTrigger:
@@ -466,7 +466,7 @@ Resources:
         Fn::GetAtt:
         - BackendProcessingLambdaRole
         - Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 60
     Type: AWS::Serverless::Function
   TestClientIAMRole:
@@ -545,7 +545,7 @@ Resources:
         Fn::GetAtt:
         - BackendProcessingLambdaRole
         - Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 60
     Type: AWS::Serverless::Function
 Transform: AWS::Serverless-2016-10-31

--- a/cloudformation/image-processing.serverless.yaml
+++ b/cloudformation/image-processing.serverless.yaml
@@ -189,7 +189,7 @@ Resources:
         Variables:
           IMAGE_METADATA_DDB_TABLE: !Ref ImageMetadataDDBTable
           STATE_MACHINE_ARN: !Ref ImageProcStateMachine
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 60
     Type: AWS::Serverless::Function
 
@@ -206,7 +206,7 @@ Resources:
       Timeout: 200
       Role:
         !GetAtt BackendProcessingLambdaRole.Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
     Type: AWS::Serverless::Function
 
   TransformMetadataFunction:
@@ -219,7 +219,7 @@ Resources:
       Timeout: 60
       Role:
         !GetAtt BackendProcessingLambdaRole.Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
     Type: AWS::Serverless::Function
 
   StoreImageMetadataFunction:
@@ -232,7 +232,7 @@ Resources:
       Timeout: 60
       Role:
         !GetAtt BackendProcessingLambdaRole.Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Environment:
         Variables:
           IMAGE_METADATA_DDB_TABLE: !Ref ImageMetadataDDBTable
@@ -246,7 +246,7 @@ Resources:
       Timeout: 60
       Role:
         !GetAtt BackendProcessingLambdaRole.Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri:
         ../lambda-functions/rekognition
     Type: AWS::Serverless::Function
@@ -261,7 +261,7 @@ Resources:
       Timeout: 300
       Role:
         !GetAtt BackendProcessingLambdaRole.Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
     Type: AWS::Serverless::Function
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -325,7 +325,7 @@ Resources:
         !GetAtt CustomResourceHelperRole.Arn
       CodeUri:
         ../lambda-functions/create-s3-event-trigger-helper
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
     Type: AWS::Serverless::Function
 
   S3EventTrigger:
@@ -443,7 +443,7 @@ Resources:
         !GetAtt DescribeExecutionFunctionRole.Arn
       CodeUri:
         ../lambda-functions/state-machine-describe-execution
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
     Type: AWS::Serverless::Function
 
   TestClientIdentityPool:


### PR DESCRIPTION
CloudFormation templates in lambda-refarch-imagerecognition have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.