### PR TITLE
Add server start up instructions for AWS Cloud9 users running the web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,27 @@ npm start
 ```
 This compiles the application, starts a local server, and opens a browser that loads the test web application (this app has been tested on **Chrome** browser only) 
  
+
+<details>
+<summary><strong> Note: AWS Cloud9 Users </strong></summary><p>
+If you're running the local web app via AWS Cloud9, due to [limitations on exposed ports for previewing an application](https://docs.aws.amazon.com/cloud9/latest/user-guide/app-preview.html#app-preview-preview-app),
+you'll have to change the port the application starts on and disable the Browsersync UI that is bundled with `lite-server`. 
+
+1. Create `bs-config.json` in `/webapp/`. (Same directory as `tsconfig.json`)
+2. Paste the following and save: 
+```
+{
+  "port": 8080,
+  "ui": false
+}
+```
+
+Then proceed as usual with `npm start`. This will ensure our web app runs on port `8080` instead of the default
+`3000` and be exposed to the Preview functionality on AWS Cloud9. 
+
+</details>
+ 
+ 
 #### Using the web app
 ##### Login
 Pick any username to log in (This is a test app to showcase the backend so it's not using real user authentication. In an actual app, you can use Amazon Cognito to manage user sign-up and login.)


### PR DESCRIPTION

*Issue #, if available: None*

*Description of changes: Tried to start this aws-sample up in AWS Cloud9 instead of my local desktop, ran into this issue where both BrowerSync UI and WebApp listen to both ports in an unsupported manner by AWS Cloud9,  and fixed it this way.*

Decided to update documentation rather than provide a separate `bs-config.json` as the defaults likely work just fine on local machine. 

Relevant limitation on AWS C9:

> If your application cannot run on any of the preceding ports or IPs, or if your application must run on more than one of these ports at the same time (**for example, your application must run on ports 8080 and 3000** at the same time), **the application preview tab might display an error or might be blank**. This is because the application preview tab within the environment works only with the preceding ports and IPs, and it works with only a single port at a time. 

ref: https://docs.aws.amazon.com/cloud9/latest/user-guide/app-preview.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
