### PR TITLE
FIX Uploading image stuck in "processing" forever

### DIFF
--- a/amplify/backend/function/S3Trigger984fb593/S3Trigger984fb593-cloudformation-template.json
+++ b/amplify/backend/function/S3Trigger984fb593/S3Trigger984fb593-cloudformation-template.json
@@ -60,7 +60,7 @@
 							"Ref": "env"
 						},
 						"STATE_MACHINE_ARN": {
-							"Fn::Sub": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${SfnStateMachineName}-master"
+							"Fn::Sub": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${SfnStateMachineName}-main"
 						},
 						"REGION": {
 							"Ref": "AWS::Region"


### PR DESCRIPTION
Hello :)

I was working on a Developing on AWS training, and wanted to run through a demo for the step functions service, so I wanted to use this reference architecture, and when I deployed it, I encountered the following issue:

*Issue #, if available:*

When uploading a new picture to the application, the image is stuck in "processing" forever. The State Machine workflow is not executed.

I went to take a look at the S3Trigger Lambda Function's log, and got the following:

```json
{
    "errorType": "Error",
    "errorMessage": "GraphQL error: Cannot return null for non-nullable type: 'String' within parent 'StartSfnExecutionResult' (/startSfnExecution/executionArn)",
    "graphQLErrors": [
        {
            "path": [
                "startSfnExecution",
                "executionArn"
            ],
            "locations": null,
            "message": "Cannot return null for non-nullable type: 'String' within parent 'StartSfnExecutionResult' (/startSfnExecution/executionArn)"
        }
    ],
    "networkError": null,
    "message": "GraphQL error: Cannot return null for non-nullable type: 'String' within parent 'StartSfnExecutionResult' (/startSfnExecution/executionArn)",
    "stack": [
        "Error: GraphQL error: Cannot return null for non-nullable type: 'String' within parent 'StartSfnExecutionResult' (/startSfnExecution/executionArn)",
        "    at new ApolloError (/var/task/node_modules/apollo-client/bundle.umd.js:85:32)",
        "    at Object.next (/var/task/node_modules/apollo-client/bundle.umd.js:890:37)",
        "    at notifySubscription (/var/task/node_modules/zen-observable/lib/Observable.js:135:18)",
        "    at onNotify (/var/task/node_modules/zen-observable/lib/Observable.js:179:3)",
        "    at SubscriptionObserver.next (/var/task/node_modules/zen-observable/lib/Observable.js:235:7)",
        "    at notifySubscription (/var/task/node_modules/zen-observable/lib/Observable.js:135:18)",
        "    at onNotify (/var/task/node_modules/zen-observable/lib/Observable.js:179:3)",
        "    at SubscriptionObserver.next (/var/task/node_modules/zen-observable/lib/Observable.js:235:7)",
        "    at notifySubscription (/var/task/node_modules/zen-observable/lib/Observable.js:135:18)",
        "    at onNotify (/var/task/node_modules/zen-observable/lib/Observable.js:179:3)"
    ]
}
```

It means that the resolver was not able to start the Step Functions Workflow (as it was not able to retrieve an execution ARN for the instance of the running workflow).

I went to look at the S3Trigger  function's environment, and it seems there is a problem with the ARN used for the state machine: it uses the word `master` instead of `main` (due to a recent update to AWS's terminology) for the State Machine's ARN.

*Description of changes:*

I updated the configuration for the S3Trigger lambda function to use the latest terminology `main` instead of `master`, and this seems to fix the problem.

Tested on an environment deployed with the 1-click-deploy feature on this repository.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
